### PR TITLE
mustang: fix video playback

### DIFF
--- a/rootdir/init.mt8163.rc
+++ b/rootdir/init.mt8163.rc
@@ -557,7 +557,7 @@ on post-fs-data
 
     #VideoCodec
     mknod /dev/Vcodec c 160 0
-    chmod 0660 /dev/Vcodec
+    chmod 0666 /dev/Vcodec
     chown media system /dev/Vcodec
 
     # DRM


### PR DESCRIPTION
YouTube, NewPipe, and other forms of video playback did not work as a result of OMX being unable to access /dev/Vcodec due to incorrect permissions. This fixes that, and now video playback works as intended.